### PR TITLE
docs: Add Resources Section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,6 +729,12 @@ Each example demonstrates:
 - Change watching and UI reactivity
 - Framework-specific integration patterns
 
+## Resources
+
+- **Interactive Examples & Playground** - *Coming Soon*
+- **Video Tutorials** - *Coming Soon*
+- **Advanced Patterns Guide** - *Coming Soon*
+
 ## Development
 
 ### Setup


### PR DESCRIPTION
Adds a new "Resources" section to the README.md file to provide links to interactive examples, video tutorials, and an advanced patterns guide.

The links are currently marked as "Coming Soon" and will be updated as the resources become available.